### PR TITLE
Add support for switching to websocket-based multiplayer

### DIFF
--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -16,6 +16,7 @@ import {
   PlayerColor,
   playerHandHeightPx,
   possibleColors,
+  useWS,
 } from "./constants/app-constants";
 import {
   cardConstants,
@@ -138,6 +139,7 @@ interface IProps {
   updateCounterValue: (payload: { id: string; delta: number }) => void;
   removeCounter: (id: string) => void;
   moveCounter: (payload: { id: string; newPos: Vector2d }) => void;
+  createNewMultiplayerGame: () => void;
   connectToRemoteGame: (peerId: string) => void;
   undo: () => void;
   redo: () => void;
@@ -2330,7 +2332,18 @@ class Game extends Component<IProps, IState> {
               }
             },
           },
-        ],
+        ].concat(
+          useWS
+            ? [
+                {
+                  label: `Start Hosting a new online game`,
+                  action: () => {
+                    this.props.createNewMultiplayerGame();
+                  },
+                },
+              ]
+            : []
+        ),
       },
       {
         label: `Copy game to clipboard`,

--- a/src/GameContainer.tsx
+++ b/src/GameContainer.tsx
@@ -63,6 +63,7 @@ import {
 import {
   clearPreviewCard,
   connectToRemoteGame,
+  createNewMultiplayerGame,
   quitGame,
   requestResync,
   setPreviewCardId,
@@ -143,6 +144,7 @@ const GameContainer = connect(mapStateToProps, {
   removeCounter,
   moveCounter,
   connectToRemoteGame,
+  createNewMultiplayerGame,
   requestResync,
   undo: ActionCreators.undo,
   redo: ActionCreators.redo,

--- a/src/PlayerHand.tsx
+++ b/src/PlayerHand.tsx
@@ -315,9 +315,6 @@ class PlayerHand extends Component<IProps, IState> {
 
   handleClickAndPointerUp =
     (card: ICardDetails) => (event: React.MouseEvent) => {
-      // const uiWebView = is_uiwebview;
-      // const uiSafariOrWebView = is_safari_or_uiwebview;
-      // console.log(uiWebView, uiSafariOrWebView);
       if (
         (event.nativeEvent as PointerEvent).pointerType === "touch" ||
         is_safari_or_uiwebview ||

--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -1,5 +1,10 @@
 import { v4 as uuidv4 } from "uuid";
 
+// For multiplayer type
+export const useDevWSServer = localStorage.getItem("__dev_ws__");
+export const useWS = localStorage.getItem("__ws_mp__");
+
+// Peer ref (for webrtc mode)
 export const myPeerRef = uuidv4();
 (window as any).myPeerRef = myPeerRef;
 

--- a/src/features/cards-data/cards-data.selectors.ts
+++ b/src/features/cards-data/cards-data.selectors.ts
@@ -38,7 +38,7 @@ export const getCardsData = createSelector(
       marvelchampions: undefined,
       lotrlcg: undefined,
     };
-    // TODO: Make this a generic loop
+    // TODO: Make this a generic loop rather than hard-coding the types
     let data = rawCardsData.data.marvelchampions;
     if (data !== undefined) {
       // This is stupid, have to do it for typescript

--- a/src/features/game/game.slice.ts
+++ b/src/features/game/game.slice.ts
@@ -31,6 +31,8 @@ const updatePositionReducer: CaseReducer<
   return state;
 };
 
+const createNewMultiplayerGameReducer: CaseReducer<IGameState> = () => {};
+
 const connectToRemoteGameReducer: CaseReducer<
   IGameState,
   PayloadAction<string>
@@ -185,6 +187,7 @@ const gameSlice = createSlice({
     updateZoom: updateZoomReducer,
     updatePosition: updatePositionReducer,
     connectToRemoteGame: connectToRemoteGameReducer,
+    createNewMultiplayerGame: createNewMultiplayerGameReducer,
     setPlayerInfo: setPlayerInfoReducer,
     setAllPlayerInfo: setAllPlayerInfoReducer,
     setPeerId: setPeerIdReducer,
@@ -249,6 +252,7 @@ export const {
   updateZoom,
   updatePosition,
   connectToRemoteGame,
+  createNewMultiplayerGame,
   setPlayerInfo,
   setAllPlayerInfo,
   setPeerId,

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -8,6 +8,7 @@ import { saveState } from "./localStorage";
 import { websocketMiddleware } from "./websocket-server-multiplayer-middleware";
 import { peerJSMiddleware } from "./peer-js-redux-middleware";
 import log from "loglevel";
+import { useWS } from "../constants/app-constants";
 
 const baseCustomizedMiddleware = getDefaultMiddleware({
   thunk: true,
@@ -15,7 +16,6 @@ const baseCustomizedMiddleware = getDefaultMiddleware({
   serializableCheck: false,
 });
 
-const useWS = localStorage.getItem("__ws_mp__");
 const wsCustomizedMiddleware =
   baseCustomizedMiddleware.concat(websocketMiddleware);
 const peerJSCustomizedMiddleware =

--- a/src/store/middleware-utilities.ts
+++ b/src/store/middleware-utilities.ts
@@ -20,6 +20,7 @@ import {
   clearMenuPreviewCardJsonId,
   clearPreviewCard,
   connectToRemoteGame,
+  createNewMultiplayerGame,
   requestResync,
   setMenuPreviewCardJsonId,
   setMultiplayerGameName,
@@ -41,6 +42,7 @@ import {
 // affect any other player's zoom.
 export const blacklistRemoteActions = {
   [connectToRemoteGame.type]: true,
+  [createNewMultiplayerGame.type]: true,
   [updatePosition.type]: true,
   [updateZoom.type]: true,
   [setPreviewCardId.type]: true,


### PR DESCRIPTION
This allows for localStorage-based switching to a websocket-based implementation for multiplayer. 

Websockets, while requiring a dedicated backend service, easily allow for >2 players without complicated additional logic. It also is a more well-documented and supported transport mechanism. 

The related backend server code can be found at https://github.com/erlloyd/cardtable-multiplayer-server. The goal of that service is still not to store any state, but just be a passthrough to pass state changes to connected clients.