### PR TITLE
Enhance the new websocket multiplayer architecture

### DIFF
--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -59,6 +59,7 @@ import CloseIcon from "@material-ui/icons/Close";
 import MoreVertIcon from "@material-ui/icons/MoreVert";
 import DeckSearchContainer from "./DeckSearchContainer";
 import log from "loglevel";
+import NotificationsContainer from "./Notifications/NotificationsContainer";
 
 const SCALE_BY = 1.02;
 
@@ -653,6 +654,7 @@ class Game extends Component<IProps, IState> {
             <div>
               <Provider store={store}>
                 <CardtableAlertsContainer></CardtableAlertsContainer>
+                <NotificationsContainer></NotificationsContainer>
               </Provider>
               <Stage
                 ref={(ref) => {
@@ -2316,14 +2318,7 @@ class Game extends Component<IProps, IState> {
             label: "Request resync from Remote Game",
             action: this.props.requestResync,
           },
-          {
-            label: `Peer id is ${this.props.peerId} (click to copy)`,
-            action: () => {
-              if (!!this.props.peerId) {
-                copyToClipboard(this.props.peerId);
-              }
-            },
-          },
+
           {
             label: `Copy my online game link`,
             action: () => {
@@ -2332,18 +2327,33 @@ class Game extends Component<IProps, IState> {
               }
             },
           },
-        ].concat(
-          useWS
-            ? [
-                {
-                  label: `Start Hosting a new online game`,
-                  action: () => {
-                    this.props.createNewMultiplayerGame();
+        ]
+          .concat(
+            !!this.props.peerId
+              ? [
+                  {
+                    label: `Peer id is ${this.props.peerId} (click to copy)`,
+                    action: () => {
+                      if (!!this.props.peerId) {
+                        copyToClipboard(this.props.peerId);
+                      }
+                    },
                   },
-                },
-              ]
-            : []
-        ),
+                ]
+              : []
+          )
+          .concat(
+            useWS
+              ? [
+                  {
+                    label: `Start hosting a new online game`,
+                    action: () => {
+                      this.props.createNewMultiplayerGame();
+                    },
+                  },
+                ]
+              : []
+          ),
       },
       {
         label: `Copy game to clipboard`,

--- a/src/Notifications/Notifications.tsx
+++ b/src/Notifications/Notifications.tsx
@@ -1,0 +1,64 @@
+import { Alert, Snackbar } from "@mui/material";
+import { useEffect, useState } from "react";
+import { INotification } from "../features/notifications/initialState";
+import isEqual from "lodash.isequal";
+import cloneDeep from "lodash.clonedeep";
+
+interface IProps {
+  hasNotification: boolean;
+  activeNotification: INotification | null;
+  clearNotification: (id: string) => void;
+}
+
+const Notifications = ({
+  activeNotification,
+  hasNotification,
+  clearNotification,
+}: IProps) => {
+  useEffect(() => {
+    setTimeout(() => {
+      clearNotification(activeNotification?.id ?? "");
+    }, 4000);
+  }, [activeNotification, clearNotification]);
+
+  // We need to save the last notification, otherwise
+  // if the notification goes to null at the same time
+  // the `hasNotification` goes to false, you still see
+  // a weird flash
+  const [lastNotification, setLastNotification] =
+    useState<INotification | null>(null);
+
+  if (
+    activeNotification !== null &&
+    !isEqual(lastNotification, activeNotification)
+  ) {
+    setLastNotification(cloneDeep(activeNotification));
+  }
+
+  const handleClose =
+    (id: string) => (_event: React.SyntheticEvent | Event, reason?: string) => {
+      if (reason === "clickaway") {
+        return;
+      }
+      clearNotification(id);
+    };
+
+  return (
+    <Snackbar
+      open={hasNotification}
+      onClose={handleClose(lastNotification?.id ?? "")}
+      anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+      sx={{ bottom: { xs: 90, sm: 90, m: 90, l: 90, xl: 90 } }}
+    >
+      <Alert
+        onClose={handleClose(lastNotification?.id ?? "")}
+        severity={lastNotification?.level ?? "success"}
+        sx={{ width: "100%" }}
+      >
+        {lastNotification?.message ?? ""}
+      </Alert>
+    </Snackbar>
+  );
+};
+
+export default Notifications;

--- a/src/Notifications/NotificationsContainer.tsx
+++ b/src/Notifications/NotificationsContainer.tsx
@@ -1,0 +1,26 @@
+import { connect } from "react-redux";
+
+import { RootState } from "../store/rootReducer";
+import Notifications from "./Notifications";
+import {
+  activeNotification,
+  hasNotification,
+} from "../features/notifications/notifications.selectors";
+import { clearNotification } from "../features/notifications/notifications.slice";
+
+export interface IProps {
+  id: string;
+}
+
+const mapStateToProps = (state: RootState) => {
+  return {
+    hasNotification: hasNotification(state),
+    activeNotification: activeNotification(state),
+  };
+};
+
+const NotificationsContainer = connect(mapStateToProps, {
+  clearNotification,
+})(Notifications);
+
+export default NotificationsContainer;

--- a/src/features/game/game.selectors.ts
+++ b/src/features/game/game.selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { RootState } from "../../store/rootReducer";
 import { ICardStack } from "../cards/initialState";
+import { useWS } from "../../constants/app-constants";
 
 export const getGame = (state: RootState) => state.game;
 
@@ -16,7 +17,9 @@ export const getPlayerNumbers = createSelector(getGame, (game) => {
   return game.playerNumbers;
 });
 
-export const getPeerId = createSelector(getGame, (game) => game.peerId);
+export const getPeerId = createSelector(getGame, (game) =>
+  useWS ? game.multiplayerGameName : game.peerId
+);
 
 export const getMultiplayerGameName = createSelector(
   getGame,

--- a/src/features/game/game.slice.ts
+++ b/src/features/game/game.slice.ts
@@ -57,6 +57,18 @@ const setAllPlayerInfoReducer: CaseReducer<
   state.playerNumbers = action.payload.numbers;
 };
 
+const removePlayerReducer: CaseReducer<IGameState, PayloadAction<string>> = (
+  state,
+  action
+) => {
+  if (!!state.playerColors[action.payload]) {
+    delete state.playerColors[action.payload];
+  }
+  if (!!state.playerNumbers[action.payload]) {
+    delete state.playerNumbers[action.payload];
+  }
+};
+
 const setPeerIdReducer: CaseReducer<IGameState, PayloadAction<string>> = (
   state,
   action
@@ -190,6 +202,7 @@ const gameSlice = createSlice({
     createNewMultiplayerGame: createNewMultiplayerGameReducer,
     setPlayerInfo: setPlayerInfoReducer,
     setAllPlayerInfo: setAllPlayerInfoReducer,
+    removePlayer: removePlayerReducer,
     setPeerId: setPeerIdReducer,
     setMultiplayerGameName: setMultiplayerGameNameReducer,
     requestResync: requestResyncReducer,
@@ -255,6 +268,7 @@ export const {
   createNewMultiplayerGame,
   setPlayerInfo,
   setAllPlayerInfo,
+  removePlayer,
   setPeerId,
   setMultiplayerGameName,
   requestResync,

--- a/src/features/game/initialState.ts
+++ b/src/features/game/initialState.ts
@@ -59,6 +59,7 @@ localStorageState.playerColors[myPeerRef] = "red";
 localStorageState.playerNumbers = {};
 localStorageState.playerNumbers[myPeerRef] = 1;
 localStorageState.peerId = "";
+localStorageState.multiplayerGameName = "";
 localStorageState.previewCard = null;
 localStorageState.menuPreviewCardJsonId = null;
 localStorageState.radialMenuPosition = null;

--- a/src/features/notifications/initialState.ts
+++ b/src/features/notifications/initialState.ts
@@ -1,0 +1,21 @@
+export type INotificationType = "error" | "warning" | "info" | "success";
+
+export interface INotification {
+  id: string;
+  message: string;
+  level: INotificationType;
+}
+
+export interface INotificationsState {
+  notificationsQueue: INotification[];
+}
+
+const defaultState: INotificationsState = {
+  notificationsQueue: [],
+};
+export const initialState: INotificationsState = {
+  ...defaultState,
+  // As of now we have nothing we want to store in localStorage... but
+  // leaving this here for reference
+  // ...localStorageState,
+};

--- a/src/features/notifications/notifications.selectors.ts
+++ b/src/features/notifications/notifications.selectors.ts
@@ -1,0 +1,19 @@
+import { createSelector } from "reselect";
+import { RootState } from "../../store/rootReducer";
+
+export const getNotifications = (state: RootState) => state.notifications;
+
+export const hasNotification = createSelector(
+  getNotifications,
+  (notificationsState) => notificationsState.notificationsQueue.length > 0
+);
+
+export const activeNotification = createSelector(
+  getNotifications,
+  (notificationsState) => notificationsState.notificationsQueue[0] ?? null
+);
+
+export const notificationList = createSelector(
+  getNotifications,
+  (notificationsState) => notificationsState.notificationsQueue
+);

--- a/src/features/notifications/notifications.slice.ts
+++ b/src/features/notifications/notifications.slice.ts
@@ -1,0 +1,38 @@
+import { CaseReducer, createSlice, PayloadAction } from "@reduxjs/toolkit";
+import {
+  INotification,
+  INotificationsState,
+  initialState,
+} from "./initialState";
+
+// Reducers
+const sendNotificationReducer: CaseReducer<
+  INotificationsState,
+  PayloadAction<INotification>
+> = (state, action) => {
+  state.notificationsQueue.push(action.payload);
+};
+
+const clearNotificationReducer: CaseReducer<
+  INotificationsState,
+  PayloadAction<string>
+> = (state, action) => {
+  state.notificationsQueue = state.notificationsQueue.filter(
+    (n) => n.id !== action.payload
+  );
+};
+
+// slice
+const notificationsSlice = createSlice({
+  name: "notifications",
+  initialState: initialState,
+  reducers: {
+    sendNotification: sendNotificationReducer,
+    clearNotification: clearNotificationReducer,
+  },
+});
+
+export const { sendNotification, clearNotification } =
+  notificationsSlice.actions;
+
+export default notificationsSlice.reducer;

--- a/src/store/middleware-utilities.ts
+++ b/src/store/middleware-utilities.ts
@@ -35,6 +35,10 @@ import {
 } from "../features/game/game.slice";
 import { toggleNotes } from "../features/notes/notes.slice";
 import {
+  clearNotification,
+  sendNotification,
+} from "../features/notifications/notifications.slice";
+import {
   receiveRemoteGameState,
   startDraggingCardFromHand,
 } from "./global.actions";
@@ -67,6 +71,8 @@ export const blacklistRemoteActions = {
   [doneLoadingJSON.type]: true,
   [bulkLoadCardsDataForPack.type]: true,
   [bulkLoadCardsForEncounterSet.type]: true,
+  [sendNotification.type]: true,
+  [clearNotification.type]: true,
 };
 
 export const misingPlayerNumInSeq = (

--- a/src/store/middleware-utilities.ts
+++ b/src/store/middleware-utilities.ts
@@ -32,6 +32,7 @@ import {
   updatePosition,
   updateZoom,
   doneLoadingJSON,
+  removePlayer,
 } from "../features/game/game.slice";
 import { toggleNotes } from "../features/notes/notes.slice";
 import {
@@ -73,6 +74,7 @@ export const blacklistRemoteActions = {
   [bulkLoadCardsForEncounterSet.type]: true,
   [sendNotification.type]: true,
   [clearNotification.type]: true,
+  [removePlayer.type]: true,
 };
 
 export const misingPlayerNumInSeq = (

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -12,6 +12,8 @@ import game, {
   stopDraggingCardFromHand,
 } from "../features/game/game.slice";
 
+import notifications from "../features/notifications/notifications.slice";
+
 import counters, { moveCounter } from "../features/counters/counters.slice";
 import arrows, {
   startNewArrowForCards,
@@ -30,6 +32,7 @@ const undoableState = combineReducers({
 const rootReducer = combineReducers({
   game,
   cardsData,
+  notifications,
   liveState: undoable(undoableState, {
     limit: 40,
     groupBy: groupByActionTypes([moveCounter.type]),


### PR DESCRIPTION
In order to support > 2 players and more consistent multiplayer, focus on enhancing the websocket version of the multiplayer server. 

The change also includes a generic and super useful notification system for displaying success, warning, info, and error notifications for a short period of time. As such, this PR also adds several locations for the notifications, mainly around multiplayer, but also for failing to load a private deck.