### PR TITLE
Add checkbox and api call for private marvel cdb decks

### DIFF
--- a/src/DeckLoader.tsx
+++ b/src/DeckLoader.tsx
@@ -1,13 +1,17 @@
 import { Component } from "react";
 import * as React from "react";
 import TextField from "@mui/material/TextField";
+import CheckBox from "@mui/material/Checkbox";
+import { FormControlLabel } from "@mui/material";
 
 interface IProps {
-  loadDeckId: (id: number) => void;
+  loadDeckId: (id: number, usePrivateApi: boolean) => void;
+  showPrivateApiOption: boolean;
 }
 
 class DeckLoader extends Component<IProps> {
-  inputValue: string = "";
+  deckId: string = "";
+  privateApiSelected: boolean = false;
 
   private focusInputField = (input: any) => {
     if (input) {
@@ -30,11 +34,23 @@ class DeckLoader extends Component<IProps> {
           onKeyPress={this.handleKeyPress}
           onClick={this.cancelBubble}
           onChange={(event) => {
-            this.inputValue = event.target.value;
+            this.deckId = event.target.value;
           }}
           type="number"
           variant="outlined"
         ></TextField>{" "}
+        <div hidden={!this.props.showPrivateApiOption}>
+          <FormControlLabel
+            label="Use Private Deck ID?"
+            control={
+              <CheckBox
+                onChange={(event) => {
+                  this.privateApiSelected = event.currentTarget.checked;
+                }}
+              />
+            }
+          ></FormControlLabel>
+        </div>
       </div>
     );
   }
@@ -45,7 +61,7 @@ class DeckLoader extends Component<IProps> {
 
   private handleKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key.toLocaleLowerCase() === "enter") {
-      this.props.loadDeckId(+this.inputValue);
+      this.props.loadDeckId(+this.deckId, this.privateApiSelected);
     }
   };
 }

--- a/src/DeckSearch.tsx
+++ b/src/DeckSearch.tsx
@@ -23,7 +23,7 @@ interface IProps {
     decklistSearchTerm: string;
     position: Vector2d;
   }) => void;
-  loadDeckId: (id: number) => void;
+  loadDeckId: (id: number, usePrivateApi: boolean) => void;
 }
 
 const focusInputField = (input: any) => {
@@ -76,7 +76,7 @@ const DeckSearch = (props: IProps) => {
           style={{ width: 300 }}
           onChange={(_, value) => {
             if (!!value) {
-              props.loadDeckId(value.Id);
+              props.loadDeckId(value.Id, false);
             }
             props.hideDeckSearch();
           }}

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -102,6 +102,7 @@ interface IProps {
   // fetchDecklistById: (payload: {
   //   gameType: GameType;
   //   decklistId: number;
+  //   usePrivateApi: boolean;
   //   position: Vector2d;
   // }) => void;
   updateZoom: (zoom: Vector2d) => void;
@@ -900,6 +901,9 @@ class Game extends Component<IProps, IState> {
   private renderDeckImporter = () => {
     if (!this.state.showDeckImporter) return null;
 
+    const privateApiAvailable =
+      !!GamePropertiesMap[this.props.currentGameType].privateDecklistApi;
+
     const containerRect = this.stage?.container().getBoundingClientRect();
     const pointerPosition = this.state.deckImporterPosition;
     if (!containerRect || !pointerPosition) {
@@ -918,6 +922,7 @@ class Game extends Component<IProps, IState> {
           loadDeckId={this.handleImportDeck(
             this.getRelativePositionFromTarget(this.stage)
           )}
+          showPrivateApiOption={privateApiAvailable}
         />
       </TopLayer>
     );
@@ -1061,11 +1066,12 @@ class Game extends Component<IProps, IState> {
     cacheImages(uniqueUrls);
   };
 
-  private handleImportDeck = (position: Vector2d) => (id: number) => {
+  private handleImportDeck = (position: Vector2d) => (id: number, usePrivateApi: boolean) => {
     this.clearDeckImporter();
     this.props.fetchDecklistById({
       gameType: this.props.currentGameType,
       decklistId: id,
+      usePrivateApi: usePrivateApi,
       position,
     });
   };
@@ -1154,10 +1160,9 @@ class Game extends Component<IProps, IState> {
       y: (pointer.y - this.stage.y()) / oldScale,
     };
 
-    const isZoomIn = event.evt.deltaY < 0 || event.evt.deltaX > 0
+    const isZoomIn = event.evt.deltaY < 0 || event.evt.deltaX > 0;
 
-    const newScale =
-      isZoomIn ? oldScale * SCALE_BY : oldScale / SCALE_BY;
+    const newScale = isZoomIn ? oldScale * SCALE_BY : oldScale / SCALE_BY;
 
     this.props.updateZoom({ x: newScale, y: newScale });
 

--- a/src/constants/game-type-properties-mapping.tsx
+++ b/src/constants/game-type-properties-mapping.tsx
@@ -5,6 +5,7 @@ import GameManager from "../game-modules/GameModuleManager";
 export interface GameProperties {
   deckSite: string;
   decklistApi: string;
+  privateDecklistApi?: string;
   decklistSearchApi: string;
   decklistSearchApiConstants?: string;
   encounterUiName: string;

--- a/src/features/cards/cards.thunks.ts
+++ b/src/features/cards/cards.thunks.ts
@@ -260,22 +260,29 @@ export const getListOfDecklistsFromSearchTerm = createAsyncThunk(
 export const fetchDecklistById = createAsyncThunk(
   "decklist/fetchByIdStatus",
   async (
-    payload: { gameType: GameType; decklistId: number; position: Vector2d },
+    payload: {
+      gameType: GameType;
+      decklistId: number;
+      usePrivateApi: boolean;
+      position: Vector2d;
+    },
     thunkApi
   ) => {
     let response;
+    const privateApiUrl =
+      GamePropertiesMap[payload.gameType].privateDecklistApi;
+    const publicApiUrl = GamePropertiesMap[payload.gameType].decklistApi;
+    // if usePrivateApi is true and the game has a private decklist endpoint available, use it. Otherwise use public
+    const apiUrl =
+      payload.usePrivateApi && privateApiUrl ? privateApiUrl : publicApiUrl;
     try {
-      response = await axios.get(
-        `${GamePropertiesMap[payload.gameType].decklistApi}${
-          payload.decklistId
-        }`
-      );
+      response = await axios.get(`${apiUrl}${payload.decklistId}`);
     } catch (e) {
       thunkApi.dispatch(
         sendNotification({
           id: uuidv4(),
           level: "error",
-          message: `Couldn't load deck ${payload.decklistId}. Ensure the id is correct and not a private deck. Cardtable can only support public decks at this time.`,
+          message: `Couldn't load deck ${payload.decklistId}. If this is a private deck, ensure "Share your decks" is checked in the user's settings.`,
         })
       );
       throw e;

--- a/src/features/cards/cards.thunks.ts
+++ b/src/features/cards/cards.thunks.ts
@@ -278,11 +278,24 @@ export const fetchDecklistById = createAsyncThunk(
     try {
       response = await axios.get(`${apiUrl}${payload.decklistId}`);
     } catch (e) {
+      let errorMessage = `Couldn't load deck ${payload.decklistId}. `;
+      if (privateApiUrl) {
+        if (payload.usePrivateApi) {
+          errorMessage +=
+            ' Ensure the id is correct and not a public deck id, and that "Share your decks" is checked in the user\'s settings.';
+        } else {
+          errorMessage +=
+            'Ensure the id is correct and not a private deck. If it is private, check the use the "private deck" option';
+        }
+      } else {
+        errorMessage +=
+          "Ensure the id is correct and not a private deck. This game can only support public decks at this time.";
+      }
       thunkApi.dispatch(
         sendNotification({
           id: uuidv4(),
           level: "error",
-          message: `Couldn't load deck ${payload.decklistId}. If this is a private deck, ensure "Share your decks" is checked in the user's settings.`,
+          message: errorMessage,
         })
       );
       throw e;

--- a/src/game-modules/GameModule.ts
+++ b/src/game-modules/GameModule.ts
@@ -77,6 +77,7 @@ export type CodeToImageMap = { [key: string]: string };
 export interface GameProperties {
   deckSite: string;
   decklistApi: string;
+  privateDecklistApi?: string;
   decklistSearchApi: string;
   decklistSearchApiConstants?: string;
   encounterUiName: string;

--- a/src/game-modules/marvel-champions/MavelChampionsGameModule.ts
+++ b/src/game-modules/marvel-champions/MavelChampionsGameModule.ts
@@ -31,6 +31,7 @@ export default class MarvelChampionsGameModule extends GameModule {
     const properties = {
       deckSite: "marvelcdb.com",
       decklistApi: "https://marvelcdb.com/api/public/decklist/",
+      privateDecklistApi: "https://marvelcdb.com/api/public/deck/",
       decklistSearchApi: "https://marvelcdb.com/decklists",
       decklistSearchApiConstants: "sort=likes",
       encounterUiName: "Encounter Set",


### PR DESCRIPTION
When loading a deck from marvel cdb, there is a separate api path fro getting private decks and public decks. This checkbox passes a boolean value down the stack to tell the function which path to use. For lotr, there is no private deck API, so we hide the checkbox by changing the game properties to see if there is a private api url configured.

I was not able to test out that the "search deck" option still works, because of cross-origin request issues. I predict it will work fine, since it passes through a "false", but probably worth double checking :)

tested on Firefox, not chrome.

Feel free to correct any React conventions I may have violated, the last time I did react was in 2016, and from the looks of it a lot has changed!