### PR TITLE
Visual counter enhancements

### DIFF
--- a/src/Counter.tsx
+++ b/src/Counter.tsx
@@ -29,6 +29,8 @@ interface IProps {
 interface IState {
   counterImageLoaded: boolean;
   hoveredOverOptions: boolean;
+  hoveredOverPlus: boolean;
+  hoveredOverMinus: boolean;
 }
 
 class Counter extends Component<IProps, IState> {
@@ -45,6 +47,8 @@ class Counter extends Component<IProps, IState> {
     this.state = {
       counterImageLoaded: false,
       hoveredOverOptions: false,
+      hoveredOverPlus: false,
+      hoveredOverMinus: false,
     };
 
     this.img = new Image();
@@ -124,20 +128,28 @@ class Counter extends Component<IProps, IState> {
         onMouseLeave={this.handleMouseLeaveCounter}
       >
         <Rect
-          cornerRadius={30}
+          cornerRadius={100}
           width={containerWidth}
           height={containerHeight}
           fill={this.props.color}
+          // stroke={"black"}
+          // strokeWidth={3}
         ></Rect>
 
         <Text
           width={containerWidth}
           height={containerHeight}
-          fontSize={36}
+          fontSize={40}
+          fontStyle="bold"
           text={`${this.props.value}`}
+          fill="white"
+          stroke={"black"}
+          strokeWidth={6}
+          fillAfterStrokeEnabled={true}
           align={"center"}
           verticalAlign={"middle"}
-          offsetY={hasAdditionalDisplay ? 20 : 0}
+          offsetY={hasText ? 10 : hasImage ? 23 : -2}
+          letterSpacing={2}
         ></Text>
         {hasImage && this.state.counterImageLoaded && (
           <Rect
@@ -157,36 +169,74 @@ class Counter extends Component<IProps, IState> {
             height={containerHeight}
             fillPatternImage={this.img}
             fontSize={24}
+            fontStyle="bold"
             text={`${this.props.counterText}`}
             align={"center"}
             verticalAlign={"bottom"}
-            offsetY={5}
+            offsetY={10}
           ></Text>
         )}
-        <Text
-          x={10}
-          y={25}
-          width={50}
-          height={50}
-          fontSize={36}
-          text={`-`}
-          align={"center"}
-          verticalAlign={"middle"}
+        <Group
+          width={40}
           onClick={this.handleDecrement}
           onTap={this.handleDecrement}
-        ></Text>
-        <Text
-          x={140}
-          y={25}
-          width={50}
-          height={50}
-          fontSize={36}
-          text={`+`}
-          align={"center"}
-          verticalAlign={"middle"}
+          onMouseEnter={this.handleMouseEnterMinusButton}
+          onMouseLeave={this.handleMouseLeaveMinusButton}
+          offsetY={hasText ? 10 : 0}
+        >
+          <Circle
+            width={40}
+            height={40}
+            fill={this.state.hoveredOverMinus ? "white" : "#e0e0e0"}
+            align={"center"}
+            verticalAlign={"middle"}
+            x={30}
+            y={50}
+            stroke="white"
+            strokeWidth={this.state.hoveredOverMinus ? 3 : 0}
+          ></Circle>
+          <Text
+            x={5}
+            y={25}
+            width={50}
+            height={50}
+            fontSize={this.state.hoveredOverMinus ? 40 : 36}
+            text={`-`}
+            align={"center"}
+            verticalAlign={"middle"}
+          ></Text>
+        </Group>
+        <Group
+          width={40}
           onClick={this.handleIncrement}
           onTap={this.handleIncrement}
-        ></Text>
+          onMouseEnter={this.handleMouseEnterPlusButton}
+          onMouseLeave={this.handleMouseLeavePlusButton}
+          offsetY={hasText ? 10 : 0}
+        >
+          <Circle
+            width={40}
+            height={40}
+            fill={this.state.hoveredOverPlus ? "white" : "#e0e0e0"}
+            align={"center"}
+            verticalAlign={"middle"}
+            x={170}
+            y={50}
+            stroke="white"
+            strokeWidth={this.state.hoveredOverPlus ? 3 : 0}
+          ></Circle>
+          <Text
+            x={145}
+            y={28}
+            width={50}
+            height={50}
+            fontSize={this.state.hoveredOverPlus ? 40 : 36}
+            text={`+`}
+            align={"center"}
+            verticalAlign={"middle"}
+            fill={this.state.hoveredOverPlus ? "black" : "#333"}
+          ></Text>
+        </Group>
 
         <Group
           width={30}
@@ -198,23 +248,22 @@ class Counter extends Component<IProps, IState> {
           <Circle
             width={30}
             height={30}
-            stroke={"black"}
-            fill={this.state.hoveredOverOptions ? "grey" : "white"}
-            opacity={0.5}
+            fill={this.state.hoveredOverOptions ? "#333" : "black"}
             align={"center"}
             verticalAlign={"middle"}
-            offsetY={-20}
-            offsetX={-25}
+            offsetY={-15}
+            offsetX={-10}
           ></Circle>
           <Text
             width={30}
             height={30}
             fontSize={24}
+            fill={this.state.hoveredOverOptions ? "white" : "#999"}
             text={"..."}
             align={"center"}
             verticalAlign={"middle"}
-            offsetX={-10}
-            offsetY={1}
+            offsetY={5}
+            offsetX={5}
           ></Text>
         </Group>
       </Group>
@@ -267,6 +316,34 @@ class Counter extends Component<IProps, IState> {
 
   private handleMouseLeaveCounter = (event: KonvaEventObject<MouseEvent>) => {
     window.document.body.style.cursor = "default";
+  };
+
+  private handleMouseEnterPlusButton = (
+    _event: KonvaEventObject<MouseEvent>
+  ) => {
+    this.setState({ hoveredOverPlus: true });
+    window.document.body.style.cursor = "pointer";
+  };
+
+  private handleMouseLeavePlusButton = (
+    _event: KonvaEventObject<MouseEvent>
+  ) => {
+    this.setState({ hoveredOverPlus: false });
+    window.document.body.style.cursor = "grab";
+  };
+
+  private handleMouseEnterMinusButton = (
+    _event: KonvaEventObject<MouseEvent>
+  ) => {
+    this.setState({ hoveredOverMinus: true });
+    window.document.body.style.cursor = "pointer";
+  };
+
+  private handleMouseLeaveMinusButton = (
+    _event: KonvaEventObject<MouseEvent>
+  ) => {
+    this.setState({ hoveredOverMinus: false });
+    window.document.body.style.cursor = "grab";
   };
 
   private handleMouseEnterMenuButton = (

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -38,6 +38,7 @@ import TokenBagsContainer from "./TokenBagsContainer";
 import TokenValueModifier from "./TokenValueModifier";
 import TopLayer from "./TopLayer";
 import {
+  COLORS,
   PlayerColor,
   myPeerRef,
   playerHandHeightPx,
@@ -424,7 +425,7 @@ class Game extends Component<IProps, IState> {
             backLinkCode={this.getCardCode(card, true)}
             name={this.getCardName(card)}
             selectedColor={
-              this.props.playerColors[card.controlledBy] ?? "black"
+              this.props.playerColors[card.controlledBy] ?? COLORS.BLACK
             }
             controlledBy={card.controlledBy}
             key={card.id}

--- a/src/GameContextMenu.tsx
+++ b/src/GameContextMenu.tsx
@@ -182,11 +182,11 @@ const createCounterContextMenuItems = (props: IProps): ContextMenuItem[] => {
       label: "Set Color",
       children: possibleColors.map((color) => {
         return {
-          label: color,
+          label: color.label,
           action: () => {
             props.updateCounterColor({
               id: props.counter!.id,
-              newColor: color,
+              newColor: color.color,
             });
           },
         };

--- a/src/constants/app-constants.ts
+++ b/src/constants/app-constants.ts
@@ -16,21 +16,35 @@ export const showHiddenGamesLocalStorage = !!localStorage.getItem(
 export const myPeerRef = uuidv4();
 (window as any).myPeerRef = myPeerRef;
 
-export type PlayerColor =
-  | "red"
-  | "cyan"
-  | "green"
-  | "blue"
-  | "magenta"
-  | "yellow";
+export const COLORS = {
+  RED: "#e74c3c",
+  BLUE: "#2980b9",
+  GREEN: "#27ae60",
+  TURQUOISE: "#1abc9c",
+  PURPLE: "#8e44ad",
+  YELLOW: "#f1c40f",
+  ORANGE: "#e67e22",
+  GRAY: "#95a5a6",
+  WHITE: "white",
+  BLACK: "black",
+} as const;
 
-export const possibleColors: PlayerColor[] = [
-  "red",
-  "blue",
-  "green",
-  "cyan",
-  "magenta",
-  "yellow",
+export type PlayerColor = (typeof COLORS)[keyof typeof COLORS];
+
+export const possibleColors: {
+  label: string;
+  color: PlayerColor;
+}[] = [
+  { label: "Red", color: COLORS.RED },
+  { label: "Blue", color: COLORS.BLUE },
+  { label: "Green", color: COLORS.GREEN },
+  { label: "Turquoise", color: COLORS.TURQUOISE },
+  { label: "Purple", color: COLORS.PURPLE },
+  { label: "Yellow", color: COLORS.YELLOW },
+  { label: "Orange", color: COLORS.ORANGE },
+  { label: "Gray", color: COLORS.GRAY },
+  { label: "White", color: COLORS.WHITE },
+  { label: "Black", color: COLORS.BLACK },
 ];
 
 export const playerHandHeightPx: number = 90;

--- a/src/features/arrows/arrows.slice.ts
+++ b/src/features/arrows/arrows.slice.ts
@@ -2,6 +2,7 @@ import { CaseReducer, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { Vector2d } from "konva/lib/types";
 import { receiveRemoteGameState, resetApp } from "../../store/global.actions";
 import { IArrowsState, initialState } from "./initialState";
+import { COLORS } from "../../constants/app-constants";
 
 // Reducers
 const startNewArrowForCardsReducer: CaseReducer<
@@ -14,7 +15,10 @@ const startNewArrowForCardsReducer: CaseReducer<
     state.arrows[action.payload.myRef] = myArrows;
   }
   state.arrows[action.payload.myRef] = myArrows.concat(
-    action.payload.startCardIds.map((sc) => ({ startCardId: sc, color: "red" }))
+    action.payload.startCardIds.map((sc) => ({
+      startCardId: sc,
+      color: COLORS.RED,
+    }))
   );
 };
 

--- a/src/features/arrows/initialState.ts
+++ b/src/features/arrows/initialState.ts
@@ -1,5 +1,5 @@
 import { Vector2d } from "konva/lib/types";
-import { myPeerRef, PlayerColor } from "../../constants/app-constants";
+import { COLORS, myPeerRef, PlayerColor } from "../../constants/app-constants";
 import { loadState } from "../../store/localStorage";
 import JSONCrush from "jsoncrush";
 
@@ -24,7 +24,7 @@ const localStorageState: IArrowsState =
   queryParamsArrows || (loadState("liveState")?.arrows ?? {});
 
 localStorageState.arrows = {
-  [myPeerRef]: [{ startCardId: "blah", color: "red" }],
+  [myPeerRef]: [{ startCardId: "blah", color: COLORS.RED }],
 };
 
 const defaultState: IArrowsState = {

--- a/src/features/counters/counters.slice.ts
+++ b/src/features/counters/counters.slice.ts
@@ -1,6 +1,6 @@
 import { CaseReducer, createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { Vector2d } from "konva/lib/types";
-import { PlayerColor } from "../../constants/app-constants";
+import { PlayerColor, COLORS } from "../../constants/app-constants";
 import { receiveRemoteGameState, resetApp } from "../../store/global.actions";
 import { addNewCounterWithId } from "./counters.actions";
 import {
@@ -131,7 +131,7 @@ const countersSlice = createSlice({
         id: action.payload.id,
         position: action.payload.pos,
         value: 0,
-        color: action.payload.color || "red",
+        color: action.payload.color || COLORS.RED,
         imgUrl: action.payload.imgUrl,
         text: action.payload.text,
       });

--- a/src/features/game/initialState.ts
+++ b/src/features/game/initialState.ts
@@ -1,5 +1,5 @@
 import { Vector2d } from "konva/lib/types";
-import { myPeerRef, PlayerColor } from "../../constants/app-constants";
+import { COLORS, myPeerRef, PlayerColor } from "../../constants/app-constants";
 import { loadState } from "../../store/localStorage";
 import { GameType } from "../../game-modules/GameType";
 import GameManager from "../../game-modules/GameModuleManager";
@@ -82,7 +82,7 @@ const localStorageState: IGameState = !!queryParamsGameType
   : loadState("game");
 
 localStorageState.playerColors = {};
-localStorageState.playerColors[myPeerRef] = "red";
+localStorageState.playerColors[myPeerRef] = COLORS.RED;
 localStorageState.playerNumbers = {};
 localStorageState.playerNumbers[myPeerRef] = 1;
 localStorageState.peerId = "";

--- a/src/game-modules/lorcana/LorcanaGameModule.ts
+++ b/src/game-modules/lorcana/LorcanaGameModule.ts
@@ -19,6 +19,7 @@ import { packList as lorcanaPackList } from "./generated/packsList";
 import { properties } from "./properties";
 import { groupBy } from "lodash";
 import { ICounter } from "../../features/counters/initialState";
+import { COLORS } from "../../constants/app-constants";
 
 interface LorcanaCard {
   quest?: string;
@@ -257,14 +258,14 @@ export default class LorcanaGameModule extends GameModule {
         id: "",
         position: { x: 0, y: 0 },
         text: "Ursula Lore",
-        color: "magenta",
+        color: COLORS.PURPLE,
         value: 0,
       },
       {
         id: "",
         position: { x: 0, y: 0 },
         text: "Ursula Draw",
-        color: "yellow",
+        color: COLORS.YELLOW,
         value: 2,
       },
     ];

--- a/src/game-modules/star-wars-deckbuilding-game/StarWarsDeckbuildingGameModule.ts
+++ b/src/game-modules/star-wars-deckbuilding-game/StarWarsDeckbuildingGameModule.ts
@@ -25,6 +25,7 @@ import { CardSizeType } from "../../constants/card-constants";
 import { v4 as uuidv4 } from "uuid";
 import { IPlayerBoard } from "../../features/cards/initialState";
 import { makeBasicPlayerBoard } from "../../utilities/playerboard-utils";
+import { COLORS } from "../../constants/app-constants";
 
 interface Scenario {
   Name: string;
@@ -350,14 +351,14 @@ export default class StarWarsDeckbuildingGameModule extends GameModule {
             id: "",
             position: { x: 0, y: 0 },
             text: "Resources",
-            color: "yellow",
+            color: COLORS.YELLOW,
             value: 0,
           },
           {
             id: "",
             position: { x: 0, y: 0 },
             text: "Resources",
-            color: "yellow",
+            color: COLORS.YELLOW,
             value: 0,
           },
         ];
@@ -367,28 +368,28 @@ export default class StarWarsDeckbuildingGameModule extends GameModule {
             id: "",
             position: { x: 0, y: 0 },
             text: "Resources",
-            color: "yellow",
+            color: COLORS.YELLOW,
             value: 0,
           },
           {
             id: "",
             position: { x: 0, y: 0 },
             text: "Resources",
-            color: "yellow",
+            color: COLORS.YELLOW,
             value: 0,
           },
           {
             id: "",
             position: { x: 0, y: 0 },
             text: "Resources",
-            color: "yellow",
+            color: COLORS.YELLOW,
             value: 0,
           },
           {
             id: "",
             position: { x: 0, y: 0 },
             text: "Resources",
-            color: "yellow",
+            color: COLORS.YELLOW,
             value: 0,
           },
         ];
@@ -399,14 +400,14 @@ export default class StarWarsDeckbuildingGameModule extends GameModule {
             id: "",
             position: { x: 0, y: 0 },
             text: "Resources",
-            color: "yellow",
+            color: COLORS.YELLOW,
             value: 0,
           },
           {
             id: "",
             position: { x: 0, y: 0 },
             text: "AI Resources",
-            color: "yellow",
+            color: COLORS.YELLOW,
             value: 0,
           },
         ];

--- a/src/game-modules/star-wars-deckbuilding-game/properties.ts
+++ b/src/game-modules/star-wars-deckbuilding-game/properties.ts
@@ -1,3 +1,4 @@
+import { COLORS } from "../../constants/app-constants";
 import {
   CardAttachLocation,
   CounterTokenType,
@@ -39,7 +40,7 @@ export const properties: GameProperties = {
     {
       counterName: "Resources",
       counterText: "Resources",
-      counterColor: "yellow",
+      counterColor: COLORS.YELLOW,
     },
   ],
   defaultAttachLocation: CardAttachLocation.UpAndRight,

--- a/src/store/peer-js-redux-middleware.ts
+++ b/src/store/peer-js-redux-middleware.ts
@@ -8,7 +8,7 @@ import {
   Config,
   uniqueNamesGenerator,
 } from "unique-names-generator";
-import { myPeerRef } from "../constants/app-constants";
+import { COLORS, myPeerRef } from "../constants/app-constants";
 import {
   connectToRemoteGame,
   requestResync,
@@ -174,14 +174,14 @@ export const peerJSMiddleware = (storeAPI: any) => {
       // this just changes the connecting client to blue
       const setPlayerInfoAction = setPlayerInfo({
         ref: activeCon.metadata.ref,
-        color: "blue",
+        color: COLORS.BLUE,
         playerNumber: 2,
       });
       activeCon.send(setPlayerInfoAction);
       activeCon.send(
         setPlayerInfo({
           ref: myPeerRef,
-          color: "red",
+          color: COLORS.RED,
           playerNumber: 1,
         })
       );


### PR DESCRIPTION
I've made a few visual refinements to counters.

**Before:**
<img src="https://github.com/user-attachments/assets/0c1f4928-e916-48d6-97f9-00a4846d92c0" width="265">

**After:**
<img src="https://github.com/user-attachments/assets/d7799ff6-c6a1-4cfe-8b23-c6f9d47b1e87" width="275">

Also works with text and image counters:
<img src="https://github.com/user-attachments/assets/2dc5400b-8fa1-4b68-a868-a585c5051a55" width="137">
<img src="https://github.com/user-attachments/assets/6e593472-b846-40c6-9792-9a7b585d7e14" width="157">

Colors are now set as a constant, and a label is applied to each to allow for more "pleasing" color options:
<img width="253" alt="Screenshot 2024-08-16 at 15 02 59@2x" src="https://github.com/user-attachments/assets/514590e3-4ef4-4a88-a665-a1bc482119f2">

As the colour values are stored with each counter instance, the color of any existing counters will **not** be changed by this update.

There is also a subtle hover effect on the + and - buttons:
<img src="https://github.com/user-attachments/assets/a0e242f7-2f23-4a0b-a101-be66b5a85a1e" width="138">

Hope this is all ok!?
